### PR TITLE
ci: NPM_TOKEN検証を冒頭に追加し、publishをRelease作成より先に実行

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,17 @@ jobs:
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Verify NPM_TOKEN
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -z "$NODE_AUTH_TOKEN" ]; then
+            echo "::error::NPM_TOKEN secret is not set"
+            exit 1
+          fi
+          # トークンの有効性を whoami で検証（無効なら 401 で非ゼロ終了）
+          npm whoami --registry=https://registry.npmjs.org/
+
       - name: Install dependencies
         run: npm ci
 
@@ -82,6 +93,11 @@ jobs:
             echo "v${VERSION} のリリース" > release_notes.md
           fi
 
+      - name: Publish to NPM
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
@@ -96,11 +112,6 @@ jobs:
             dist/datapage.d.ts
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Publish to NPM
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create release summary
         run: |


### PR DESCRIPTION
## Summary
- リリースワークフロー冒頭に `npm whoami` による NPM_TOKEN 検証ステップを追加し、無効/未設定なら早期fail
- `npm publish` を `Create GitHub Release` より先に実行する順序へ変更し、publish失敗時にGitHub Releaseだけ作られてしまう不整合を防止

## Why
無効な NPM_TOKEN のまま lint → build → unit test → Playwright E2E（3ブラウザ）まで全部走らせてから publish で失敗するのはムダ。さらに従来の順序（先にRelease作成 → 後でpublish）だと、publish失敗時に GitHub Release だけ残って npm 未公開という中途半端な状態になり、再実行時もコンフリクトしやすい。

## 再実行について
GitHub Actions 標準の "Re-run jobs" で再実行可能。新順序であれば
- 検証ステップで落ちた場合 → 副作用ゼロで安全に再実行できる
- publish 後に Release作成で落ちた場合 → 同タグへの再 publish は npm が拒否するため、その時は Release作成ステップだけ手動 or `softprops/action-gh-release` の冪等性に任せる

## Test plan
- [ ] 次回リリース時に検証ステップが通過することを確認
- [ ] （シミュレーション可能なら）NPM_TOKEN を一時的に無効値にして冒頭で fail することを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow with explicit authentication verification before build and deployment steps.
  * Optimized release process sequence for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->